### PR TITLE
在config中设置jieba词典的路径

### DIFF
--- a/rasa_nlu/tokenizers/jieba_tokenizer.py
+++ b/rasa_nlu/tokenizers/jieba_tokenizer.py
@@ -16,10 +16,6 @@ from rasa_nlu.training_data import TrainingData
 
 import glob
 import jieba
-# Add jieba userdict file
-jieba_userdicts = glob.glob("./jieba_userdict/*")
-for jieba_userdict in jieba_userdicts:
-    jieba.load_userdict(jieba_userdict)
 
 
 class JiebaTokenizer(Tokenizer, Component):
@@ -29,14 +25,26 @@ class JiebaTokenizer(Tokenizer, Component):
 
     provides = ["tokens"]
     
-    def __init__(self):
-        pass
+    def __init__(self, jieba_dict_dir):
+        # Add jieba userdict file
+        jieba_userdicts = glob.glob(jieba_dict_dir+"/*")
+        for jieba_userdict in jieba_userdicts:
+            jieba.load_userdict(jieba_userdict)
        
 
     @classmethod
     def required_packages(cls):
         # type: () -> List[Text]
         return ["jieba"]
+
+    @classmethod
+    def create(cls, config):
+        return cls(config['jieba_dict_dir'])
+
+    @classmethod
+    def load(cls, model_dir=None, model_metadata=None, cached_component=None, **kwargs):
+        config = kwargs['config']
+        return cached_component if cached_component else cls(config['jieba_dict_dir'])
 
     def train(self, training_data, config, **kwargs):
         # type: (TrainingData, RasaNLUConfig, **Any) -> None


### PR DESCRIPTION
在config文件里添加这个："jieba_dict_dir": "./jieba_userdict/"。
变成：
'''
{
  "name": "rasa_nlu_test",
  "pipeline": ["nlp_mitie",
        "tokenizer_jieba",
        "ner_mitie",
        "ner_synonyms",
        "intent_entity_featurizer_regex",
        "intent_featurizer_mitie",
        "intent_classifier_sklearn"],
  "language": "zh",
  "mitie_file": "./data/total_word_feature_extractor_zh.dat",
  "path" : "./models",
  "data" : "./data/examples/rasa/demo-rasa_zh.json",
  "jieba_dict_dir": "./jieba_userdict/"
}
```

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
